### PR TITLE
Log specific error to fix fatal warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ let () =
     (* Handling of errors. `operation_result` has the type `('a, Postgresql.error) result`. *)
     match operation_result with
     | Ok () -> print_endline "Operations were successful!" |> Lwt.return
-    | Error _ -> print_endline "An error occurred." |> Lwt.return
+    | Error e -> print_endline (Postgresql.string_of_error e)  |> Lwt.return
   )
 ```
 
@@ -149,7 +149,7 @@ let () =
     (* Handling of errors. `operation_result` has the type `('a, Postgresql.error) result`. *)
     match operation_result with
     | Ok () -> print_endline "Operations were successful!" |> Lwt.return
-    | Error _ -> print_endline "An error occurred." |> Lwt.return
+    | Error e -> print_endline (Postgresql.string_of_error e)  |> Lwt.return
   )
 ```
 
@@ -196,6 +196,6 @@ let () =
     (* Handling of errors. *)
     match operation_result with
     | Ok () -> print_endline "Operations were successful!" |> Lwt.return
-    | Error _ -> print_endline "An error occurred." |> Lwt.return
+    | Error e -> print_endline (Postgresql.string_of_error e)  |> Lwt.return
   )
 ```


### PR DESCRIPTION
Copying the examples in a dune project resulted in a fatal warning because the variable `e` wasn't used. (Probably it's possible to configure things to make this non-fatal?) Seems more useful to log the error message anyway.